### PR TITLE
Allow custom-command to "install" itself

### DIFF
--- a/custom/build.py
+++ b/custom/build.py
@@ -11,3 +11,9 @@ class Command(setuptools.Command):
 
     def run(self):
         log.info("brrrrrrrrr")
+
+
+def install(dist):
+    # This could be protected by a opt-in condition...
+    build = dist.get_command_obj("build")
+    build.sub_commands = [*build.sub_commands, ("custom-build", None)]

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,5 @@ packages = find_namespace:
 [options.entry_points]
 distutils.commands =
 	custom-build = custom.build:Command
+setuptools.finalize_distribution_options =
+	custom-build = custom.build:install


### PR DESCRIPTION
Hi Jason, thank you very much for demonstrating how to use sub-commands with setuptools.

I was thinking about it lately (there is a non-zero number of users asking guidance on this topic), and I noticed that we can use the `finalize_distribution_options` hook to automatically install the sub-command, without requiring the final users to add custom logic to their `setup.py` file.

The objective of this PR is to give an example for that process.

(I demonstrated this strategy in https://github.com/abravalheri/experiment-setuptools-plugin)